### PR TITLE
Comment in json file prevents it being parsed correctly

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,19 +1,3 @@
-/*
-# Copyright 2016 - Wipro Limited
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-*/
-
 {
   "node_server_port":3300,
   "dashboard_server_ip":"10.200.208.19",


### PR DESCRIPTION
License commit prevents the `default.json` from being parsed with the following error message

``` C:\wsp\galaxia-ui\node_modules\config\lib\config.js:887
    throw new Error("Cannot parse config file: '" + fullFilename + "': " + e3);
    ^

Error: Cannot parse config file: 'C:\wsp\galaxia-ui\config\default.json': SyntaxError: Unexpected t
oken / in JSON at position 0
    at util.parseFile (C:\wsp\galaxia-ui\node_modules\config\lib\config.js:887:11)
    at C:\wsp\galaxia-ui\node_modules\config\lib\config.js:686:28
    at Array.forEach (native)
    at C:\wsp\galaxia-ui\node_modules\config\lib\config.js:682:14
    at Array.forEach (native)
    at util.loadFileConfigs (C:\wsp\galaxia-ui\node_modules\config\lib\config.js:681:13)
    at new Config (C:\wsp\galaxia-ui\node_modules\config\lib\config.js:119:27)
    at Object.<anonymous> (C:\wsp\galaxia-ui\node_modules\config\lib\config.js:1690:31)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
```
